### PR TITLE
Add detection for missing gui pinentry

### DIFF
--- a/tpmfido.go
+++ b/tpmfido.go
@@ -65,6 +65,11 @@ func newServer() *server {
 
 func (s *server) run() {
 	ctx := context.Background()
+
+	if pinentry.FindPinentryGUIPath() == "" {
+		log.Printf("warning: no gui pinentry binary detected in PATH. tpm-fido may not work correctly without a gui based pinentry")
+	}
+
 	token, err := fidohid.New(ctx, "tpm-fido")
 	if err != nil {
 		log.Fatalf("create fido hid error: %s", err)


### PR DESCRIPTION
Detect if a common gui based pin entry is available. If not print a warning and fallback to plain `pinentry`.

If you only have a text based pinentry, you won't see any prompt and you will likely be confused why tpm-fido isn't working.

Fixes #9