### PR TITLE
Implemented multiseat support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 tpm-fido is FIDO token implementation for Linux that protects the token keys by using your system's TPM. tpm-fido uses Linux's [uhid](https://github.com/psanford/uhid) facility to emulate a USB HID device so that it is properly detected by browsers.
 
-##  Implementation details
+## Implementation details
 
 tpm-fido uses the TPM 2.0 API. The overall design is as follows:
 
@@ -43,6 +43,14 @@ To run:
 ./tpm-fido
 ```
 Note: do not run with `sudo` or as root, as it will not work.
+
+## Multiseat support
+In order to use `tpm-fido` with multiple users/seats (via `loginctl`), create `/etc/udev/rules.d/70-tpm-fido.rules` with the following content:
+```
+SUBSYSTEM=="hidraw", KERNELS=="0003:15D9:0A37.*", IMPORT{parent}="HID_NAME"
+SUBSYSTEM=="hidraw", ENV{HID_NAME}=="tpm-fido", ENV{ID_PATH_TAG}=="", ENV{ID_PATH_TAG}="$env{HID_NAME}-$attr{country}"
+```
+Then you'll be able to `loginctl assign` the device to whatever seat you need.
 
 ## Dependencies
 

--- a/fidohid/fidohid.go
+++ b/fidohid/fidohid.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os/user"
+	"strconv"
 
 	"github.com/psanford/tpm-fido/fidoauth"
 	"github.com/psanford/uhid"
@@ -22,6 +24,18 @@ func New(ctx context.Context, name string) (*SoftToken, error) {
 	d.Data.Bus = busUSB
 	d.Data.VendorID = vendorID
 	d.Data.ProductID = productID
+
+	u, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Data.Country = uint32(uid)
 
 	evtChan, err := d.Open(ctx)
 	if err != nil {


### PR DESCRIPTION
**Abstract:** `tpm-fido` can run multi-user, but any virtual device created by either instance would go to `seat0` with no way to reassign it.

---

`loginctl assign` requires `ID_FOR_SEAT` property to be set on the device, which is missing for `hidraw` devices due to `ID_PATH_TAG` not being set for those:
```sh
# /usr/lib/udev/rules.d/71-seat.rules
TAG=="seat", ENV{ID_FOR_SEAT}=="", ENV{ID_PATH_TAG}!="", ENV{ID_FOR_SEAT}="$env{SUBSYSTEM}-$env{ID_PATH_TAG}"
```

In order to add `ID_PATH_TAG`, we needed some way to distinguish between users' uhid devices. I came up with the following construction numbered lower than the aforementioned rule:
```sh
# /etc/udev/rules.d/70-tpm-fido.rules
SUBSYSTEM=="hidraw", KERNELS=="0003:15D9:0A37.*", IMPORT{parent}="HID_NAME"
SUBSYSTEM=="hidraw", ENV{HID_NAME}=="tpm-fido", ENV{ID_PATH_TAG}=="", ENV{ID_PATH_TAG}="$env{HID_NAME}-$attr{country}"
```

Clearly, I am using the `country` parent attribute here, but where does it come from? See psanford/uhid#2 to find out ;)
> _Note: I chose to use UID for the value, which gets truncated to 8 bits, but that's diverse enough for *most* multiseat configuration out in the wild._