### PR TITLE
Implement `pinentry` Program Override

### DIFF
--- a/pinentry/pinentry.go
+++ b/pinentry/pinentry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -139,6 +140,11 @@ func (pe *Pinentry) prompt(req *request, prompt string) {
 }
 
 func FindPinentryGUIPath() string {
+	override := os.Getenv("PINENTRY_PROGRAM")
+	if override != "" {
+		return override
+	}
+
 	candidates := []string{
 		"pinentry-gnome3",
 		"pinentry-qt5",


### PR DESCRIPTION
Mitigate #29

A user can now use the environment variable `PINENTRY_PROGRAM` to specify a `pinentry` program that they prefer.

Tested on KDE: `PINENTRY_PROGRAM=pinentry-qt5 ./tpm-fido` works well.